### PR TITLE
feat(secondaryFilters) passing secondaryFilter to optionsUrl if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.launch
 .settings/
 *.sublime-workspace
+*.iml
 
 # IDE - VSCode
 .vscode/*

--- a/projects/novo-elements/src/services/options/OptionsService.ts
+++ b/projects/novo-elements/src/services/options/OptionsService.ts
@@ -8,13 +8,16 @@ export class OptionsService {
   constructor() {}
 
   getOptionsConfig(http: HttpClient, field: any, config: { token?: string; restUrl?: string; military?: boolean }): any {
+    const secondaryFilterParam =
+      field.secondaryFilter && field.secondaryFilter.length > 0 ? `&secondaryFilter=${field.secondaryFilter}` : '';
+
     return {
       field: 'value',
       format: '$label',
       options: (query) => {
         return new Promise((resolve, reject) => {
           if (query && query.length) {
-            http.get(`${field.optionsUrl}?filter=${query || ''}`).subscribe(resolve, reject);
+            http.get(`${field.optionsUrl}?filter=${query || ''}${secondaryFilterParam}`).subscribe(resolve, reject);
           } else {
             resolve([]);
           }


### PR DESCRIPTION
## **Description**

INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

#### **Verify that...**

- [ ] Any related demos were added and `npm start` and `npm run build` still works
- [ ] New demos work in `Safari`, `Chrome` and `Firefox`
- [ ] `npm run lint` passes
- [ ] `npm test` passes and code coverage is increased
- [ ] `npm run build` still works

#### **Bullhorn Internal Developers**
- [ ] Run `Novo Automation`
- [ ] Run `BBO Automation`

##### **Screenshots**